### PR TITLE
omx: Improve debug messages for null buffers

### DIFF
--- a/media/libstagefright/omx/OMXNodeInstance.cpp
+++ b/media/libstagefright/omx/OMXNodeInstance.cpp
@@ -687,7 +687,7 @@ status_t OMXNodeInstance::useBuffer(
         OMX_U32 portIndex, const sp<IMemory> &params,
         OMX::buffer_id *buffer, OMX_U32 allottedSize) {
     if (params == NULL || buffer == NULL) {
-        ALOGE("b/25884056");
+        ALOGE("b/25884056 %d", __LINE__);
         return BAD_VALUE;
     }
 
@@ -736,7 +736,7 @@ status_t OMXNodeInstance::useGraphicBuffer2_l(
         OMX_U32 portIndex, const sp<GraphicBuffer>& graphicBuffer,
         OMX::buffer_id *buffer) {
     if (graphicBuffer == NULL || buffer == NULL) {
-        ALOGE("b/25884056");
+        ALOGE("b/25884056 %d", __LINE__);
         return BAD_VALUE;
     }
 
@@ -792,7 +792,7 @@ status_t OMXNodeInstance::useGraphicBuffer(
         OMX_U32 portIndex, const sp<GraphicBuffer>& graphicBuffer,
         OMX::buffer_id *buffer) {
     if (graphicBuffer == NULL || buffer == NULL) {
-        ALOGE("b/25884056");
+        ALOGE("b/25884056 %d", __LINE__);
         return BAD_VALUE;
     }
     Mutex::Autolock autoLock(mLock);
@@ -857,7 +857,7 @@ status_t OMXNodeInstance::updateGraphicBufferInMeta_l(
         OMX::buffer_id buffer, OMX_BUFFERHEADERTYPE *header, bool updateCodecBuffer) {
     // No need to check |graphicBuffer| since NULL is valid for it as below.
     if (header == NULL) {
-        ALOGE("b/25884056");
+        ALOGE("b/25884056 %d", __LINE__);
         return BAD_VALUE;
     }
 
@@ -914,7 +914,7 @@ status_t OMXNodeInstance::updateNativeHandleInMeta(
     OMX_BUFFERHEADERTYPE *header = findBufferHeader(buffer, portIndex);
     // No need to check |nativeHandle| since NULL is valid for it as below.
     if (header == NULL) {
-        ALOGE("b/25884056");
+        ALOGE("b/25884056 %d", __LINE__);
         return BAD_VALUE;
     }
 
@@ -1013,7 +1013,7 @@ status_t OMXNodeInstance::createInputSurface(
         OMX_U32 portIndex, android_dataspace dataSpace,
         sp<IGraphicBufferProducer> *bufferProducer, MetadataBufferType *type) {
     if (bufferProducer == NULL) {
-        ALOGE("b/25884056");
+        ALOGE("b/25884056 %d", __LINE__);
         return BAD_VALUE;
     }
 
@@ -1035,7 +1035,7 @@ status_t OMXNodeInstance::createPersistentInputSurface(
         sp<IGraphicBufferProducer> *bufferProducer,
         sp<IGraphicBufferConsumer> *bufferConsumer) {
     if (bufferProducer == NULL || bufferConsumer == NULL) {
-        ALOGE("b/25884056");
+        ALOGE("b/25884056 %d", __LINE__);
         return BAD_VALUE;
     }
     String8 name("GraphicBufferSource");
@@ -1088,7 +1088,7 @@ status_t OMXNodeInstance::allocateSecureBuffer(
         OMX_U32 portIndex, size_t size, OMX::buffer_id *buffer,
         void **buffer_data, sp<NativeHandle> *native_handle) {
     if (buffer == NULL || buffer_data == NULL || native_handle == NULL) {
-        ALOGE("b/25884056");
+        ALOGE("b/25884056 %d", __LINE__);
         return BAD_VALUE;
     }
 
@@ -1140,7 +1140,7 @@ status_t OMXNodeInstance::allocateBufferWithBackup(
         OMX_U32 portIndex, const sp<IMemory> &params,
         OMX::buffer_id *buffer, OMX_U32 allottedSize) {
     if (params == NULL || buffer == NULL) {
-        ALOGE("b/25884056");
+        ALOGE("b/25884056 %d", __LINE__);
         return BAD_VALUE;
     }
 
@@ -1192,7 +1192,7 @@ status_t OMXNodeInstance::freeBuffer(
 
     OMX_BUFFERHEADERTYPE *header = findBufferHeader(buffer, portIndex);
     if (header == NULL) {
-        ALOGE("b/25884056");
+        ALOGE("b/25884056 %d", __LINE__);
         return BAD_VALUE;
     }
     BufferMeta *buffer_meta = static_cast<BufferMeta *>(header->pAppPrivate);
@@ -1212,7 +1212,7 @@ status_t OMXNodeInstance::fillBuffer(OMX::buffer_id buffer, int fenceFd) {
 
     OMX_BUFFERHEADERTYPE *header = findBufferHeader(buffer, kPortIndexOutput);
     if (header == NULL) {
-        ALOGE("b/25884056");
+        ALOGE("b/25884056 %d", __LINE__);
         return BAD_VALUE;
     }
     header->nFilledLen = 0;
@@ -1249,7 +1249,7 @@ status_t OMXNodeInstance::emptyBuffer(
 
     OMX_BUFFERHEADERTYPE *header = findBufferHeader(buffer, kPortIndexInput);
     if (header == NULL) {
-        ALOGE("b/25884056");
+        ALOGE("b/25884056 %d", __LINE__);
         return BAD_VALUE;
     }
     BufferMeta *buffer_meta =
@@ -1404,7 +1404,7 @@ status_t OMXNodeInstance::emptyGraphicBuffer(
         OMX_BUFFERHEADERTYPE *header, const sp<GraphicBuffer> &graphicBuffer,
         OMX_U32 flags, OMX_TICKS timestamp, int fenceFd) {
     if (header == NULL) {
-        ALOGE("b/25884056");
+        ALOGE("b/25884056 %d", __LINE__);
         return BAD_VALUE;
     }
 
@@ -1562,7 +1562,7 @@ bool OMXNodeInstance::handleMessage(omx_message &msg) {
         OMX_BUFFERHEADERTYPE *buffer =
             findBufferHeader(msg.u.extended_buffer_data.buffer, kPortIndexOutput);
         if (buffer == NULL) {
-            ALOGE("b/25884056");
+            ALOGE("b/25884056 %d", __LINE__);
             return false;
         }
 
@@ -1710,7 +1710,7 @@ OMX_ERRORTYPE OMXNodeInstance::OnEvent(
         OMX_IN OMX_U32 nData2,
         OMX_IN OMX_PTR pEventData) {
     if (pAppData == NULL) {
-        ALOGE("b/25884056");
+        ALOGE("b/25884056 %d", __LINE__);
         return OMX_ErrorBadParameter;
     }
     OMXNodeInstance *instance = static_cast<OMXNodeInstance *>(pAppData);
@@ -1727,7 +1727,7 @@ OMX_ERRORTYPE OMXNodeInstance::OnEmptyBufferDone(
         OMX_IN OMX_PTR pAppData,
         OMX_IN OMX_BUFFERHEADERTYPE* pBuffer) {
     if (pAppData == NULL) {
-        ALOGE("b/25884056");
+        ALOGE("b/25884056 %d", __LINE__);
         return OMX_ErrorBadParameter;
     }
     OMXNodeInstance *instance = static_cast<OMXNodeInstance *>(pAppData);
@@ -1745,7 +1745,7 @@ OMX_ERRORTYPE OMXNodeInstance::OnFillBufferDone(
         OMX_IN OMX_PTR pAppData,
         OMX_IN OMX_BUFFERHEADERTYPE* pBuffer) {
     if (pAppData == NULL) {
-        ALOGE("b/25884056");
+        ALOGE("b/25884056 %d", __LINE__);
         return OMX_ErrorBadParameter;
     }
     OMXNodeInstance *instance = static_cast<OMXNodeInstance *>(pAppData);


### PR DESCRIPTION
 * The log message printed here simply references a Google
   bug number, and it's identical in a dozen places. Print the
   line number in case we bump into this problem.

Change-Id: Ibb462656adf53cf773b4ddb946a8f1d21113c1e5